### PR TITLE
Update RouteSubscriber.php

### DIFF
--- a/modules/iq_blog_like_dislike/src/Routing/RouteSubscriber.php
+++ b/modules/iq_blog_like_dislike/src/Routing/RouteSubscriber.php
@@ -18,7 +18,7 @@ class RouteSubscriber extends RouteSubscriberBase {
       $route->setDefaults([
         '_controller' => '\Drupal\iq_blog_like_dislike\Controller\LikeDislikeController::handler',
       ]);
-      // Remove CSRF token generation, since this would require a user session to work properly.
+      // Disable CSRF token generation, since this would require a user session to work properly.
       $requirements = $route->getRequirements();
       unset($requirements['_csrf_token']);
       $route->setRequirements($requirements);      


### PR DESCRIPTION
There was some user session available in your dev environment, that allowed CSRF validation to work. You could try that using an incognito window I guess (if you haven't already)

On the live instance, without a user session available the CSRF seed which is needed for validation is not stored and therefore CSRF validation fails.

This is a way to override the CSRF token from the like_dislike.manager route; setting it to 'FALSE' will not do the trick