### PR TITLE
update_patch_for_publication_date

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "extra": {
     "patches": {
       "drupal/publication_date": {
-        "[https://dgo.to/3210972]: Handle scheduler": "https://www.drupal.org/files/issues/2023-11-23/publication_date-scheduler_handler-3210972-9.patch"
+        "[https://dgo.to/3210972]: Handle scheduler": "https://www.drupal.org/files/issues/2023-11-23/publication_date-scheduler_handler-3210972-10.patch"
       }
     }
   }


### PR DESCRIPTION
This PR update the patch on drupal/publication_date module to add the proper datetime.time service as argument of the PublicationDateSubscriber