### PR TITLE
replace JSON::decode() with json_decode()

### DIFF
--- a/modules/iq_blog_like_dislike/src/Controller/LikeDislikeController.php
+++ b/modules/iq_blog_like_dislike/src/Controller/LikeDislikeController.php
@@ -99,7 +99,7 @@ class LikeDislikeController extends ControllerBase {
     $response = new AjaxResponse();
 
     // Decode the url data.
-    $dataDecoded = Json::decode(base64_decode((string) $data));
+    $dataDecoded = json_decode(base64_decode((string) $data));
 
     // Load the entity content.
     $entity = $this->entityTypeManager


### PR DESCRIPTION
Uses PHP `json_decode()` function to ensure decoded value is a PHP object, instead of an associative array